### PR TITLE
bugfix: DragLinearLayout animation conflicts with LayoutTransition

### DIFF
--- a/library/src/main/java/com/jmedeisis/draglinearlayout/DragLinearLayout.java
+++ b/library/src/main/java/com/jmedeisis/draglinearlayout/DragLinearLayout.java
@@ -61,6 +61,8 @@ public class DragLinearLayout extends LinearLayout {
 
     private OnViewSwapListener swapListener;
 
+    private LayoutTransition layoutTransition;
+
     /**
      * Mapping from child index to drag-related info container.
      * Presence of mapping implies the child can be dragged, and is considered for swaps with the
@@ -351,6 +353,13 @@ public class DragLinearLayout extends LinearLayout {
     }
 
     private void startDrag() {
+        // remove layout transition, it conflicts with drag animation
+        // we will restore it after drag animation end, see stopDrag()
+        layoutTransition = getLayoutTransition();
+        if (layoutTransition != null) {
+            setLayoutTransition(null);
+        }
+
         draggedItem.onDragStart();
         requestDisallowInterceptTouchEvent(true);
     }
@@ -392,6 +401,11 @@ public class DragLinearLayout extends LinearLayout {
 
                 if (null != dragTopShadowDrawable) dragTopShadowDrawable.setAlpha(255);
                 dragBottomShadowDrawable.setAlpha(255);
+
+                // restore layout transition
+                if (layoutTransition != null && getLayoutTransition() == null) {
+                    setLayoutTransition(layoutTransition);
+                }
             }
         });
         draggedItem.settleAnimation.start();


### PR DESCRIPTION
An exception is thrown when add `android:animateLayoutChanges="true"` to DragLinearLayout:

````
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
            at android.view.ViewGroup.addViewInner(ViewGroup.java:3562)
            at android.view.ViewGroup.addView(ViewGroup.java:3415)
            at android.view.ViewGroup.addView(ViewGroup.java:3360)
            at com.jmedeisis.draglinearlayout.DragLinearLayout.onDrag(DragLinearLayout.java:447)
            at com.jmedeisis.draglinearlayout.DragLinearLayout.onTouchEvent(DragLinearLayout.java:661)
            at android.view.View.dispatchTouchEvent(View.java:7714)
            at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2210)
            at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:1945)
            at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2216)
            at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:1959)
            at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2216)
````