### PR TITLE
Fix for dragg in scroll view

### DIFF
--- a/library/src/main/java/com/jmedeisis/draglinearlayout/DragLinearLayout.java
+++ b/library/src/main/java/com/jmedeisis/draglinearlayout/DragLinearLayout.java
@@ -362,6 +362,9 @@ public class DragLinearLayout extends LinearLayout {
         draggableChildren.get(position).endExistingAnimation();
 
         draggedItem.startDetectingOnPossibleDrag(child, position);
+        if (containerScrollView != null) {
+            containerScrollView.requestDisallowInterceptTouchEvent(true);
+        }
     }
 
     private void startDrag() {


### PR DESCRIPTION
Thanks to that we don't have to slowly move finger to dragg element.

When we move really fast finger scroll view will take this touch and drag will be canceled.
